### PR TITLE
fix: CI workflow issues blocking Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
-        file: ./cobertura.xml
+        files: ./cobertura.xml
         fail_ci_if_error: false
 
   build:
@@ -52,7 +52,7 @@ jobs:
         components: rustfmt, clippy
     
     - name: Build release binary
-      run: make release
+      run: make build-release
     
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR fixes CI issues that are causing all Dependabot PRs to fail:

1. **Build job failure**: Changed `make release` to `make build-release` in the build job. The `release` target requires a VERSION environment variable and is meant for creating releases with tags, not for building release binaries.

2. **Codecov warning**: Updated the codecov action parameter from `file` to `files` to be compatible with codecov-action v5 (which Dependabot PR #1 is trying to update to).

These fixes will allow the Dependabot PRs to pass CI and be merged.